### PR TITLE
feat: Add labels for slashing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Usage of validator-exporter:
 "GRPC_TLS_ENABLED" envDefault:"true"
 "GRPC_TIMEOUT_SECONDS" envDefault:"5"
 "PREFIX" envDefault:"archway"
+"CHAIN_NAME" envDefault:"archway"
+"CHAIN_ID" envDefault:"constantine-3"
 ```
 ### Connecting to archway constantine testnet by default
 ```
@@ -34,7 +36,7 @@ GRPC_TLS_ENABLED=false GRPC_ADDR=localhost:9090 validator-exporter --log-level d
 ```
 # HELP cosmos_validator_missed_blocks Returns missed blocks for a validator.
 # TYPE cosmos_validator_missed_blocks gauge
-cosmos_validator_missed_blocks{moniker="validator_1",valcons="archwayvalcons18le5pevj6sdynyksn77n9z9g8394l3xqk04s3z",valoper="archwayvaloper172zqrqtrwfplwhec44050dhuv66ekcmty4hnfv"} 0
-cosmos_validator_missed_blocks{moniker="validator_2",valcons="archwayvalcons1z4q9zpe8l8puwv8aq4dqadkz4zm244pnu72qcd",valoper="archwayvaloper1370vgzkv5l3kylcylwekzjcdt2hjk2k8zrht6c"} 0
-cosmos_validator_missed_blocks{moniker="validator_3",valcons="archwayvalcons1ep8hnygqw8gvsdfvyanhcfsmvlrvae4s9hljta",valoper="archwayvaloper1scxt3mgxmw3z2hpf8k4mlssz5qvljmtaplv6nz"} 2
+cosmos_validator_missed_blocks{bond_status="bonded",chain_id="localnet",chain_name="archway",jailed="false",moniker="validator_1",tombstoned="false",valcons="archwayvalcons1gzfu5aqsqsljmgs5m3eyklwq9ufrpmlfhxhxjd",valoper="archwayvaloper172zqrqtrwfplwhec44050dhuv66ekcmty4hnfv"} 0
+cosmos_validator_missed_blocks{bond_status="bonded",chain_id="localnet",chain_name="archway",jailed="false",moniker="validator_2",tombstoned="false",valcons="archwayvalcons1yf253kfa2g3qk2727nltndzll546wrrtdr5d3x",valoper="archwayvaloper1370vgzkv5l3kylcylwekzjcdt2hjk2k8zrht6c"} 0
+cosmos_validator_missed_blocks{bond_status="bonded",chain_id="localnet",chain_name="archway",jailed="false",moniker="validator_3",tombstoned="false",valcons="archwayvalcons1ve4g3nth72p6jq92d5cfk9kq0j48jr0m5h7wk5",valoper="archwayvaloper1scxt3mgxmw3z2hpf8k4mlssz5qvljmtaplv6nz"} 2
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/caarlos0/env/v10 v10.0.0
 	github.com/cosmos/cosmos-sdk v0.50.2
 	github.com/prometheus/client_golang v1.17.0
+	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.26.0
 	google.golang.org/grpc v1.60.0
 )
@@ -123,7 +124,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.16.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tendermint/go-amino v0.16.0 // indirect

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,9 +23,14 @@ var missedBlocks = prometheus.NewDesc(
 	missedBlocksMetricName,
 	"Returns missed blocks for a validator.",
 	[]string{
+		"chain_name",
+		"chain_id",
 		"valcons",
 		"valoper",
 		"moniker",
+		"jailed",
+		"tombstoned",
+		"bond_status",
 	},
 	nil,
 )
@@ -70,9 +76,14 @@ func (vc ValidatorsCollector) missedBlocksMetrics(vals []types.Validator) []prom
 				prometheus.GaugeValue,
 				float64(val.MissedBlocks),
 				[]string{
+					vc.Cfg.ChainName,
+					vc.Cfg.ChainID,
 					val.ConsAddress,
 					val.OperatorAddress,
 					val.Moniker,
+					strconv.FormatBool(val.Jailed),
+					strconv.FormatBool(val.Tombstoned),
+					val.BondStatus,
 				}...,
 			),
 		)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,10 +18,12 @@ func configError(msg string) error {
 }
 
 type Config struct {
-	Addr    string `env:"GRPC_ADDR" envDefault:"grpc.constantine.archway.tech:443"`
-	TLS     bool   `env:"GRPC_TLS_ENABLED" envDefault:"true"`
-	Timeout int    `env:"GRPC_TIMEOUT_SECONDS" envDefault:"5"`
-	Prefix  string `env:"PREFIX" envDefault:"archway"`
+	Addr      string `env:"GRPC_ADDR" envDefault:"grpc.constantine.archway.tech:443"`
+	TLS       bool   `env:"GRPC_TLS_ENABLED" envDefault:"true"`
+	Timeout   int    `env:"GRPC_TIMEOUT_SECONDS" envDefault:"5"`
+	Prefix    string `env:"PREFIX" envDefault:"archway"`
+	ChainName string `env:"CHAIN_NAME" envDefault:"archway"`
+	ChainID   string `env:"CHAIN_ID" envDefault:"constantine-3"`
 }
 
 func (c Config) GRPCConn() (*grpc.ClientConn, error) {

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -244,5 +244,6 @@ func LatestBlockHeight(ctx context.Context, cfg config.Config) (int64, error) {
 
 func bondStatus(status staking.BondStatus) string {
 	statusWithoutPrefix, _ := strings.CutPrefix(status.String(), bondStatusPrefix)
+	
 	return strings.ToLower(statusWithoutPrefix)
 }

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -244,6 +244,6 @@ func LatestBlockHeight(ctx context.Context, cfg config.Config) (int64, error) {
 
 func bondStatus(status staking.BondStatus) string {
 	statusWithoutPrefix, _ := strings.CutPrefix(status.String(), bondStatusPrefix)
-	
+
 	return strings.ToLower(statusWithoutPrefix)
 }

--- a/pkg/grpc/grpc_test.go
+++ b/pkg/grpc/grpc_test.go
@@ -1,0 +1,17 @@
+package grpc
+
+import (
+	"testing"
+
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBondStatus(t *testing.T) {
+	status := staking.Bonded
+
+	exp := "bonded"
+	res := bondStatus(status)
+
+	assert.Equal(t, exp, res)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -5,4 +5,7 @@ type Validator struct {
 	ConsAddress     string
 	MissedBlocks    int64
 	Moniker         string
+	Jailed          bool
+	Tombstoned      bool
+	BondStatus      string
 }


### PR DESCRIPTION
PR adds extra labels for `cosmos_validator_missed_blocks` metric to be able to detect slash events